### PR TITLE
Refactor Project Structure and Rename

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,9 +9,11 @@
 name: Continuous Integration
 
 on:
-  pull_request:
+  push:
     branches:
       - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -44,16 +46,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
-      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: 8.7
-
       - name: Build and analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew build sonar --info
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,9 +8,9 @@ val postgresql_version: String by project
 val mockkVersion: String by project
 
 plugins {
-    kotlin("jvm") version "1.9.24"
-    id("io.ktor.plugin") version "2.3.11"
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.24"
+    kotlin("jvm") version "1.9.23"
+    id("io.ktor.plugin") version "2.3.10"
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.23"
     id("org.sonarqube") version "4.4.1.3373"
     id("jacoco")
 }
@@ -29,6 +29,7 @@ sonar {
     properties {
         property("sonar.projectKey", "postech-food-challenge_products-ms")
         property("sonar.organization", "postech-food-challenge")
+        property("sonar.gradle.skipCompile", "true")
         property("sonar.host.url", "https://sonarcloud.io")
         property(
             "sonar.coverage.jacoco.xmlReportPaths",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,14 +27,11 @@ application {
 
 sonar {
     properties {
-        property("sonar.projectKey", "postech-food-challenge_products-ms")
+        property("sonar.projectKey", "postech-food-challenge_product-service")
         property("sonar.organization", "postech-food-challenge")
         property("sonar.gradle.skipCompile", "true")
         property("sonar.host.url", "https://sonarcloud.io")
-        property(
-            "sonar.coverage.jacoco.xmlReportPaths",
-            "${layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
-        )
+        property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ktor_version=2.3.9
-kotlin_version=1.9.24
+kotlin_version=1.9.23
 logback_version=1.4.14
 kotlin.code.style=official
 koin_version=3.5.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "products-ms"
+rootProject.name = "product-service"


### PR DESCRIPTION
This PR refactors the project structure to align with our microservices architecture (`br.com.fiap.postech`) and renames the project to order-service.

- Maintaining the same version across microservices.
- Updated project name to product-service.